### PR TITLE
Lock-in Provider version

### DIFF
--- a/d-aks-cni-overlay/terraform/providers.tf
+++ b/d-aks-cni-overlay/terraform/providers.tf
@@ -2,7 +2,7 @@ terraform {
   required_providers {
     azurerm = {
       source  = "hashicorp/azurerm"
-      version = "~>3"
+      version = "~>3.16.0" # see https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/container_group
     }
     random = {
       source  = "hashicorp/random"


### PR DESCRIPTION
Hello Tomas,

Thanks for this interesting read.
While testing it, I hit provider limitation.
To preserve scenario functionality without changes, I propose to lock-in supported provider version.
Otherwise modify `httpbin.tf` as follows:
```hcl
resource "azurerm_container_group" "httpbin" {
  #network_profile_id = azurerm_network_profile.httpbin.id
  subnet_ids = [ azurerm_subnet.aci.id ]
  ...
}
```